### PR TITLE
remove autoloads which require evil

### DIFF
--- a/evil-text-object-python.el
+++ b/evil-text-object-python.el
@@ -68,13 +68,11 @@
                (point))))
     (evil-range beg end)))
 
-;;;###autoload
 (evil-define-text-object
   evil-text-object-python-inner-statement (count &optional beg end type)
   "Inner text object for the Python statement under point."
   (evil-text-object-python--make-text-object count type))
 
-;;;###autoload
 (evil-define-text-object
   evil-text-object-python-outer-statement (count &optional beg end type)
   "Outer text object for the Python statement under point."


### PR DESCRIPTION
Otherwise, user can get

`Error: (void-function evil-define-text-object)`

if evil is not already require'd, which sort of takes away the point of
autoloading. Also, errors on startup just due to installation (no
touching of .emacs.d/init.el) can be quite confusing.
